### PR TITLE
Preventing trying to get property of non-object when the image field is not required

### DIFF
--- a/src/Core/Model.php
+++ b/src/Core/Model.php
@@ -287,7 +287,9 @@ class Model extends Queryable implements \Serializable {
 
       $wp_image = wp_get_attachment_image_src( $image, 'full');
       $img->full = $wp_image[0];
-      $img->caption = get_post($image)->post_excerpt;
+      if (!empty(get_post($image))) {
+        $img->caption = get_post($image)->post_excerpt;
+      }
 
       $retorno = $img;
 


### PR DESCRIPTION
![screen shot 2015-09-02 at 17 57 17](https://cloud.githubusercontent.com/assets/1436946/9644629/9692a5f6-519d-11e5-9b07-394b403586f2.png)
